### PR TITLE
Create 2.6.6.md

### DIFF
--- a/2.6.6.md
+++ b/2.6.6.md
@@ -1,0 +1,17 @@
+# Ruby 2.6.6
+
+```
+export optflags="-Wno-error=implicit-function-declaration";
+export LDFLAGS="-L/opt/homebrew/opt/libffi/lib";
+export CPPFLAGS="-I/opt/homebrew/opt/libffi/include";
+export PKG_CONFIG_PATH="/opt/homebrew/opt/libffi/lib/pkgconfig";
+export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl) --without-tcl --without-tk --with-readline-dir=$(brew --prefix readline)"
+rbenv install 2.6.6
+```
+
+Source: https://github.com/rbenv/ruby-build/issues/1699#issuecomment-762122911
+
+Adapted to make it work with the NextPoint project.
+
+#### Verified by
+- [Josias Schneider](https://github.com/josiasds) on an M2 Macbook Pro on MacOS Ventura 13.3.1 using `rbenv`.


### PR DESCRIPTION
I recently had trouble to make Ruby 2.6.6 work with an M2 MacBook and Owen found the solution.

It was an old project with a lot of dependencies, so I had to add some extra flags to make it work as expected.